### PR TITLE
Add support for providing a binary path in the repo json

### DIFF
--- a/src/Package.cpp
+++ b/src/Package.cpp
@@ -39,6 +39,7 @@ Package::Package(int state)
     this->downloads = 0;
 
 	this->category = "_all";
+	this->binary = "none";
 
 	this->status = state;
 }

--- a/src/Package.hpp
+++ b/src/Package.hpp
@@ -39,6 +39,7 @@ class Package
     std::string changelog;
     std::string url;
     std::string updated;
+    std::string binary;
     int updated_timestamp = 0;
     
     int downloads = 0;

--- a/src/Repo.cpp
+++ b/src/Repo.cpp
@@ -137,6 +137,8 @@ void Repo::loadPackages(std::vector<Package*>* packages)
         
 		if ((*it).HasMember("category"))
 			package->category = (*it)["category"].GetString();
+		if ((*it).HasMember("binary"))
+			package->binary = (*it)["binary"].GetString();
 		package->repoUrl = &this->url;
 
 		// save the response string to cleanup later


### PR DESCRIPTION
Allows the repo json to include a "binary" value in each package for front ends to execute