### PR TITLE
Fix usage of tabs in a sea of spaces in repogen.py

### DIFF
--- a/web/repogen.py
+++ b/web/repogen.py
@@ -77,12 +77,12 @@ for package in os.listdir("packages"):
             fname = os.path.join(root, file)
             folder_size += os.path.getsize(fname)/1024
 
-	# Include the nro name in json if exists
-	binary = "none"
-	for (root, dirs, files) in os.walk('.'):
-		for file in files:
-			if file.endswith(".nro"):
-				binary = (root + "/" + file)[1:]
+    # Include the nro name in json if exists
+    binary = "none"
+    for (root, dirs, files) in os.walk('.'):
+        for file in files:
+            if file.endswith(".nro"):
+                binary = (root + "/" + file)[1:]
 
 
     # Date last updated (assumption is that if the app is updated the info.json would be)


### PR DESCRIPTION
The tabs being mixed in caused the script to not run